### PR TITLE
Add LABELS env variable for labels to apply when creating issues.

### DIFF
--- a/github-issue-opener/README.md
+++ b/github-issue-opener/README.md
@@ -13,7 +13,7 @@ it like this:
 # TODO: pre-reqs like ko/google providers.
 
 module "issue-opener" {
-  source = "github.com/chainguard-dev/enforce-events//github-issue-opener/iac"
+  source = "github.com/chainguard-dev/enforce-events/github-issue-opener/iac"
 
   # name is used to prefix resources created by this demo application
   # where possible.
@@ -39,6 +39,9 @@ module "issue-opener" {
   # will be opened.
   github_org  = "chainguard-dev"
   github_repo = "mono"
+
+  # These are the labels that get applied to opened issues.
+  labels = "label1,label2,label3"
 }
 ```
 

--- a/github-issue-opener/README.md
+++ b/github-issue-opener/README.md
@@ -13,7 +13,7 @@ it like this:
 # TODO: pre-reqs like ko/google providers.
 
 module "issue-opener" {
-  source = "github.com/chainguard-dev/enforce-events/github-issue-opener/iac"
+  source = "github.com/chainguard-dev/enforce-events//github-issue-opener/iac"
 
   # name is used to prefix resources created by this demo application
   # where possible.

--- a/github-issue-opener/cmd/app/main.go
+++ b/github-issue-opener/cmd/app/main.go
@@ -21,12 +21,13 @@ import (
 )
 
 type envConfig struct {
-	Issuer      string `envconfig:"ISSUER_URL" required:"true"`
-	Group       string `envconfig:"GROUP" required:"true"`
-	Port        int    `envconfig:"PORT" default:"8080" required:"true"`
-	GithubOrg   string `envconfig:"GITHUB_ORG" required:"true"`
-	GithubRepo  string `envconfig:"GITHUB_Repo" required:"true"`
-	GithubToken string `envconfig:"GITHUB_TOKEN" required:"true"`
+	Issuer      string   `envconfig:"ISSUER_URL" required:"true"`
+	Group       string   `envconfig:"GROUP" required:"true"`
+	Port        int      `envconfig:"PORT" default:"8080" required:"true"`
+	GithubOrg   string   `envconfig:"GITHUB_ORG" required:"true"`
+	GithubRepo  string   `envconfig:"GITHUB_REPO" required:"true"`
+	GithubToken string   `envconfig:"GITHUB_TOKEN" required:"true"`
+	Labels      []string `envconfig:"LABELS" required:"false"`
 }
 
 func main() {
@@ -100,7 +101,8 @@ func main() {
 			}
 
 			issue, _, err := client.Issues.Create(ctx, env.GithubOrg, env.GithubRepo, &github.IssueRequest{
-				Title: ptr(fmt.Sprintf("Policy %s failed", name)),
+				Title:  ptr(fmt.Sprintf("Policy %s failed", name)),
+				Labels: &env.Labels,
 				Body: ptr(strings.Join([]string{
 					fmt.Sprintf("Image:        `%s`", data.Body.ImageID),
 					fmt.Sprintf("Cluster       `%s`", data.Body.ClusterID),

--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -74,6 +74,10 @@ resource "google_cloud_run_service" "gh-iss" {
           value = var.github_repo
         }
         env {
+          name  = "LABELS"
+          value = "policy-failure"
+        }
+        env {
           name = "GITHUB_TOKEN"
           value_from {
             secret_key_ref {

--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     ko = {
-      source  = "ko-build/ko"
+      source = "ko-build/ko"
     }
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
     }
   }
 }
@@ -75,7 +75,7 @@ resource "google_cloud_run_service" "gh-iss" {
         }
         env {
           name  = "LABELS"
-          value = "policy-failure"
+          value = var.labels
         }
         env {
           name = "GITHUB_TOKEN"

--- a/github-issue-opener/iac/variables.tf
+++ b/github-issue-opener/iac/variables.tf
@@ -33,3 +33,8 @@ variable "github_repo" {
   type        = string
   description = "The github repository in which to open issues for policy violations."
 }
+
+variable "labels" {
+  type        = string
+  description = "The labels (comma separated) to open issues with for policy violations."
+}


### PR DESCRIPTION
Add LABELS as an environment variable that you can use to configure the labels to assign when creating issues.
Fix oddly named environmental variable: GITHUB_Repo => GITHUB_REPO
Fix the double / in the README.md source field.
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>