### PR TITLE
Make some small style tweaks to slack sample.

### DIFF
--- a/slack-webhook/README.md
+++ b/slack-webhook/README.md
@@ -30,8 +30,8 @@ module "issue-opener" {
   # This is used to authenticate the events we receive are from Chainguard.
   env = "enforce.dev"
 
-  # The Chainguard IAM group from which we expect to receive events.
-  # This is used to authenticate that the Chainguard events are intended
+  # The Chainguard IAM group ID (not the name!) from which we expect to receive
+  # events. This is used to authenticate that the Chainguard events are intended
   # for you, and not another user.
   group = var.chainguard_iam_group
 

--- a/slack-webhook/cmd/app/event.go
+++ b/slack-webhook/cmd/app/event.go
@@ -9,7 +9,6 @@ package main
 // SDK along with our API clients.
 
 import (
-	"encoding/json"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
@@ -18,8 +17,10 @@ type Occurrence struct {
 	Actor *Actor `json:"actor,omitempty"`
 
 	// Body is the resource that was created.
-	// For this sample, it will always be ImagePolicyRecord.
-	Body json.RawMessage `json:"body,omitempty"`
+	// For this sample, it will always be one of:
+	// - ImagePolicyRecord (for continuous verification), or
+	// - admissionv1.AdmissionReview (for admission control).
+	Body interface{} `json:"body,omitempty"`
 }
 
 // Actor is the event payload form of which identity was responsible for the


### PR DESCRIPTION
Drop the `env.Debug` checks on logs, they are harmless, it is the slack notifications that we want to hide most of the time.

Use `interface{}` and provide the type for `event.As` to use to avoid two deserialization calls, and eliminate the `log.Fatalf` from the request path.