### PR TITLE
fix import path after module update

### DIFF
--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -43,7 +43,7 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 
 resource "ko_image" "image" {
   base_image  = "ghcr.io/distroless/static"
-  importpath  = "chainguard.dev/demos/github-issue-opener/cmd/app"
+  importpath  = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
   working_dir = path.module
 }
 

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -43,7 +43,7 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 
 resource "ko_image" "image" {
   base_image  = "ghcr.io/distroless/static"
-  importpath  = "chainguard.dev/demos/slack-webhook/cmd/app"
+  importpath  = "github.com/chainguard-dev/enforce-events/slack-webhook/cmd/app"
   working_dir = path.module
 }
 


### PR DESCRIPTION
fix terraform module build breakage

PR https://github.com/chainguard-dev/enforce-events/pull/8 changed the go package module name
needed to update the resource ko_image importpath

fix: https://github.com/chainguard-dev/mono/issues/5498

Signed-off-by: Kenny Leung <kleung@chainguard.dev>