### PR TITLE
use ko_build TF resource

### DIFF
--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -41,7 +41,7 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
   member    = "serviceAccount:${google_service_account.gh-iss-opener.email}"
 }
 
-resource "ko_image" "image" {
+resource "ko_build" "image" {
   base_image  = "ghcr.io/distroless/static"
   importpath  = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
   working_dir = path.module
@@ -56,7 +56,7 @@ resource "google_cloud_run_service" "gh-iss" {
     spec {
       service_account_name = google_service_account.gh-iss-opener.email
       containers {
-        image = ko_image.image.image_ref
+        image = ko_build.image.image_ref
         env {
           name  = "ISSUER_URL"
           value = "https://issuer.${var.env}"

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -41,7 +41,7 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
   member    = "serviceAccount:${google_service_account.slack-notifier.email}"
 }
 
-resource "ko_image" "image" {
+resource "ko_build" "image" {
   base_image  = "ghcr.io/distroless/static"
   importpath  = "github.com/chainguard-dev/enforce-events/slack-webhook/cmd/app"
   working_dir = path.module
@@ -56,7 +56,7 @@ resource "google_cloud_run_service" "slack-notifier" {
     spec {
       service_account_name = google_service_account.slack-notifier.email
       containers {
-        image = ko_image.image.image_ref
+        image = ko_build.image.image_ref
         env {
           name  = "CONSOLE_URL"
           value = "https://console.${var.env}"


### PR DESCRIPTION
https://github.com/ko-build/terraform-provider-ko/pull/53 -- merged but not yet released -- changes the `ko_image` resource to be named `ko_build`. It keeps the `ko_image` resource defined, but a no-op, so that the resource can more easily be deleted.

Waiting for https://github.com/ko-build/terraform-provider-ko/releases/tag/v0.0.7 to be released and picked up by terraform.

