### PR TITLE
use correct ko provider

### DIFF
--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ko = {
-      source  = "chainguard-dev/ko"
+      source  = "ko-build/ko"
     }
     google = {
       source  = "hashicorp/google"

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ko = {
-      source  = "chainguard-dev/ko"
+      source  = "ko-build/ko"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
The `chainguard-dev/ko` provider is very old, and doesn't have `ko_build`.