### PR TITLE
Add artifact registry creation to terraform main.tf files

### DIFF
--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -42,9 +42,10 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 }
 
 resource "ko_build" "image" {
-  base_image  = "ghcr.io/distroless/static"
+  base_image  = "cgr.dev/chainguard/static"
   importpath  = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
   working_dir = path.module
+  repo        = "${var.location}-docker.pkg.dev/${var.project_id}/${var.name}/github-issue-opener"
 }
 
 resource "google_cloud_run_service" "gh-iss" {

--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -41,6 +41,14 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
   member    = "serviceAccount:${google_service_account.gh-iss-opener.email}"
 }
 
+resource "google_artifact_registry_repository" "gh-iss-repo" {
+  project       = var.project_id
+  location      = var.location
+  repository_id = var.name
+  description   = "Enforce Events GitHub Issue Opener Repository"
+  format        = "DOCKER"
+}
+
 resource "ko_build" "image" {
   base_image  = "cgr.dev/chainguard/static"
   importpath  = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"

--- a/github-issue-opener/iac/variables.tf
+++ b/github-issue-opener/iac/variables.tf
@@ -37,5 +37,5 @@ variable "github_repo" {
 variable "labels" {
   type        = string
   description = "The labels (comma separated) to open issues with for policy violations."
-  default     = ""
+  default     = "enforce-events"
 }

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -42,9 +42,10 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 }
 
 resource "ko_build" "image" {
-  base_image  = "ghcr.io/distroless/static"
+  base_image  = "cgr.dev/chainguard/static"
   importpath  = "github.com/chainguard-dev/enforce-events/slack-webhook/cmd/app"
   working_dir = path.module
+  repo        = "${var.location}-docker.pkg.dev/${var.project_id}/${var.name}/slack-notifier"
 }
 
 resource "google_cloud_run_service" "slack-notifier" {

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -41,6 +41,14 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
   member    = "serviceAccount:${google_service_account.slack-notifier.email}"
 }
 
+resource "google_artifact_registry_repository" "slack-notifier-repo" {
+  project       = var.project_id
+  location      = var.location
+  repository_id = var.name
+  description   = "Enforce Events Slack Notifier Repository"
+  format        = "DOCKER"
+}
+
 resource "ko_build" "image" {
   base_image  = "cgr.dev/chainguard/static"
   importpath  = "github.com/chainguard-dev/enforce-events/slack-webhook/cmd/app"


### PR DESCRIPTION
This PR makes a couple changes to the terraform modules:

1. Updates ko to use cgr.dev/chainguard/static image
2. Computes an artifact registry location for built image (terraform bails out without this set)
3. Creates the artifact registry for the image
4. Adds a default `enforce-events` label to issues. Github API was rejecting new issues with blank labels.