### PR TITLE
Update ko_build repo location and use wolfi static image in IAC modules

### DIFF
--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -9,6 +9,10 @@ terraform {
   }
 }
 
+variable "ko_build_importpath" {
+  default = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
+}
+
 resource "google_service_account" "gh-iss-opener" {
   project    = var.project_id
   account_id = "${var.name}-issue-opener"
@@ -42,9 +46,10 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 }
 
 resource "ko_build" "image" {
-  base_image  = "ghcr.io/distroless/static"
-  importpath  = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
+  base_image  = "cgr.dev/chainguard/static:latest-glibc"
+  importpath = var.ko_build_importpath
   working_dir = path.module
+  repo        = "gcr.io/${var.project_id}/${var.ko_build_importpath}"
 }
 
 resource "google_cloud_run_service" "gh-iss" {

--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -47,7 +47,7 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 
 resource "ko_build" "image" {
   base_image  = "cgr.dev/chainguard/static:latest-glibc"
-  importpath = var.ko_build_importpath
+  importpath  = var.ko_build_importpath
   working_dir = path.module
   repo        = "gcr.io/${var.project_id}/${var.ko_build_importpath}"
 }

--- a/github-issue-opener/iac/main.tf
+++ b/github-issue-opener/iac/main.tf
@@ -9,8 +9,8 @@ terraform {
   }
 }
 
-variable "ko_build_importpath" {
-  default = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
+locals {
+  importpath = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
 }
 
 resource "google_service_account" "gh-iss-opener" {
@@ -47,9 +47,10 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 
 resource "ko_build" "image" {
   base_image  = "cgr.dev/chainguard/static:latest-glibc"
-  importpath  = var.ko_build_importpath
+  importpath  = local.importpath
   working_dir = path.module
-  repo        = "gcr.io/${var.project_id}/${var.ko_build_importpath}"
+  # repo overrides KO_DOCKER_REPO environment variable
+  repo        = "gcr.io/${var.project_id}/${local.importpath}"
 }
 
 resource "google_cloud_run_service" "gh-iss" {

--- a/github-issue-opener/iac/variables.tf
+++ b/github-issue-opener/iac/variables.tf
@@ -37,5 +37,5 @@ variable "github_repo" {
 variable "labels" {
   type        = string
   description = "The labels (comma separated) to open issues with for policy violations."
-  default     = ""
+  default     = "enforce-events"
 }

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -9,8 +9,8 @@ terraform {
   }
 }
 
-variable "ko_build_importpath" {
-  default = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
+locals {
+  importpath = "github.com/chainguard-dev/enforce-events/slack-webhook/cmd/app"
 }
 
 resource "google_service_account" "slack-notifier" {
@@ -47,9 +47,10 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 
 resource "ko_build" "image" {
   base_image  = "ghcr.io/distroless/static"
-  importpath  = var.ko_build_importpath
+  importpath  = local.importpath
   working_dir = path.module
-  repo        = "gcr.io/${var.project_id}/${var.ko_build_importpath}"
+  # repo overrides KO_DOCKER_REPO environment variable
+  repo        = "gcr.io/${var.project_id}/${local.importpath}"
 }
 
 resource "google_cloud_run_service" "slack-notifier" {

--- a/slack-webhook/iac/main.tf
+++ b/slack-webhook/iac/main.tf
@@ -9,6 +9,10 @@ terraform {
   }
 }
 
+variable "ko_build_importpath" {
+  default = "github.com/chainguard-dev/enforce-events/github-issue-opener/cmd/app"
+}
+
 resource "google_service_account" "slack-notifier" {
   project    = var.project_id
   account_id = "${var.name}-slack-notifier"
@@ -43,8 +47,9 @@ resource "google_secret_manager_secret_iam_member" "grant-secret-access" {
 
 resource "ko_build" "image" {
   base_image  = "ghcr.io/distroless/static"
-  importpath  = "github.com/chainguard-dev/enforce-events/slack-webhook/cmd/app"
+  importpath  = var.ko_build_importpath
   working_dir = path.module
+  repo        = "gcr.io/${var.project_id}/${var.ko_build_importpath}"
 }
 
 resource "google_cloud_run_service" "slack-notifier" {

--- a/slack-webhook/main.tf
+++ b/slack-webhook/main.tf
@@ -1,6 +1,0 @@
-module "slack-webhook" {
-  source     = "github.com/chainguard-dev/enforce-events/slack-webhook/iac"
-  name       = "enforce-events"
-  project_id = "jamon-chainguard"
-  group      = "jamon-test"
-}

--- a/slack-webhook/main.tf
+++ b/slack-webhook/main.tf
@@ -1,0 +1,6 @@
+module "slack-webhook" {
+  source     = "github.com/chainguard-dev/enforce-events/slack-webhook/iac"
+  name       = "enforce-events"
+  project_id = "jamon-chainguard"
+  group      = "jamon-test"
+}


### PR DESCRIPTION
Giving this update another try, this time using a variable in each IAC module to define the location of the `ko_build` repo.

I think it should prevent CI failures that have `KO_DOCKER_REPO` set, since the computed value ends up equaling the environment variable version.