### PR TITLE
image-copy-ecr: support immutable tags

### DIFF
--- a/image-copy-ecr/iac/lambda.tf
+++ b/image-copy-ecr/iac/lambda.tf
@@ -65,7 +65,7 @@ resource "aws_ecr_repository_policy" "policy" {
 
 resource "aws_ecr_repository" "repo" {
   name                 = var.dst_repo
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = var.immutable_tags ? "IMMUTABLE" : "MUTABLE"
 
   image_scanning_configuration {
     scan_on_push = false
@@ -108,12 +108,13 @@ resource "aws_lambda_function" "lambda" {
 
   environment {
     variables = {
-      GROUP         = var.group
-      IDENTITY      = chainguard_identity.aws.id
-      ISSUER_URL    = "https://issuer.enforce.dev"
-      DST_REPO      = var.dst_repo
-      FULL_DST_REPO = aws_ecr_repository.repo.repository_url
-      REGION        = data.aws_region.current.name
+      GROUP          = var.group
+      IDENTITY       = chainguard_identity.aws.id
+      ISSUER_URL     = "https://issuer.enforce.dev"
+      DST_REPO       = var.dst_repo
+      FULL_DST_REPO  = aws_ecr_repository.repo.repository_url
+      REGION         = data.aws_region.current.name
+      IMMUTABLE_TAGS = var.immutable_tags
     }
   }
 }

--- a/image-copy-ecr/iac/variables.tf
+++ b/image-copy-ecr/iac/variables.tf
@@ -7,3 +7,9 @@ variable "dst_repo" {
   type        = string
   description = "The destination repo where images should be copied to."
 }
+
+variable "immutable_tags" {
+  type        = bool
+  description = "Whether to enable immutable tags."
+  default     = false
+}


### PR DESCRIPTION
This adds a TF variable `-var=immutable_tags=true` that configures ECR repos to enforce immutable tags, and configures the copy function to append the first six digits of the image digest to any tag it pushes, so that tags can be immutable.

When immutable tags are enabled, pushing to `cgr.dev/imjasonh.dev/random:foo` mirrors an image to ECR at `<account>.dkr.ecr.<region>.amazonaws.com/<dst-repo>/random:foo-abcdef`.