### PR TITLE
avoid responding with 500 when decoding message

### DIFF
--- a/github-issue-opener/cmd/app/main.go
+++ b/github-issue-opener/cmd/app/main.go
@@ -49,15 +49,11 @@ func main() {
 			return nil
 		}
 
-		data := events.Occurrence{}
+		data := events.Occurrence{Body: policy.ImagePolicyRecord{}}
 		if err := event.DataAs(&data); err != nil {
-			return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal data: %w", err)
+			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
-
-		body, ok := data.Body.(policy.ImagePolicyRecord)
-		if !ok {
-			return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal body: %v", data.Body)
-		}
+		body := data.Body
 		for name, pol := range body.Policies {
 			if pol.Valid {
 				// Not in violation of policy
@@ -75,8 +71,8 @@ func main() {
 				Title:  ptr(fmt.Sprintf("Policy %s failed", name)),
 				Labels: &env.Labels,
 				Body: ptr(strings.Join([]string{
-					fmt.Sprintf("Image:        `%s`", body.ImageID),
-					fmt.Sprintf("Cluster       `%s`", body.ClusterID),
+					fmt.Sprintf("Image:        `%s`", data.Body.ImageID),
+					fmt.Sprintf("Cluster       `%s`", data.Body.ClusterID),
 					fmt.Sprintf("Policy:       `%s`", name),
 					fmt.Sprintf("Last Checked: `%v`", pol.LastChecked.Time),
 					fmt.Sprintf("Diagnostic:   `%v`", pol.Diagnostic),

--- a/github-issue-opener/cmd/app/main.go
+++ b/github-issue-opener/cmd/app/main.go
@@ -49,11 +49,11 @@ func main() {
 			return nil
 		}
 
-		data := events.Occurrence{Body: policy.ImagePolicyRecord{}}
+		body := &policy.ImagePolicyRecord{}
+		data := events.Occurrence{Body: body}
 		if err := event.DataAs(&data); err != nil {
 			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
-		body := data.Body
 		for name, pol := range body.Policies {
 			if pol.Valid {
 				// Not in violation of policy
@@ -71,8 +71,8 @@ func main() {
 				Title:  ptr(fmt.Sprintf("Policy %s failed", name)),
 				Labels: &env.Labels,
 				Body: ptr(strings.Join([]string{
-					fmt.Sprintf("Image:        `%s`", data.Body.ImageID),
-					fmt.Sprintf("Cluster       `%s`", data.Body.ClusterID),
+					fmt.Sprintf("Image:        `%s`", body.ImageID),
+					fmt.Sprintf("Cluster       `%s`", body.ClusterID),
 					fmt.Sprintf("Policy:       `%s`", name),
 					fmt.Sprintf("Last Checked: `%v`", pol.LastChecked.Time),
 					fmt.Sprintf("Diagnostic:   `%v`", pol.Diagnostic),

--- a/image-copy-ecr/cmd/app/main.go
+++ b/image-copy-ecr/cmd/app/main.go
@@ -88,14 +88,13 @@ func handler(ctx context.Context, levent events.LambdaFunctionURLRequest) (resp 
 		log.Printf("event type is %q, skipping", levent.Headers["ce-type"])
 		return "", nil
 	}
-	data := cgevents.Occurrence{}
+	data := cgevents.Occurrence{
+		Body: registry.PushEvent{},
+	}
 	if err := json.Unmarshal([]byte(levent.Body), &data); err != nil {
 		return "", fmt.Errorf("unable to unmarshal event: %w", err)
 	}
-	body, ok := data.Body.(registry.PushEvent)
-	if !ok {
-		return "", fmt.Errorf("event body is not a push event, skipping: %+v", body)
-	}
+	body := data.Body
 	if body.Error != nil {
 		log.Printf("event body has error, skipping: %+v", body.Error)
 		return "", nil

--- a/image-copy-ecr/cmd/app/main.go
+++ b/image-copy-ecr/cmd/app/main.go
@@ -88,13 +88,11 @@ func handler(ctx context.Context, levent events.LambdaFunctionURLRequest) (resp 
 		log.Printf("event type is %q, skipping", levent.Headers["ce-type"])
 		return "", nil
 	}
-	data := cgevents.Occurrence{
-		Body: registry.PushEvent{},
-	}
+	body := &registry.PushEvent{}
+	data := cgevents.Occurrence{Body: body}
 	if err := json.Unmarshal([]byte(levent.Body), &data); err != nil {
 		return "", fmt.Errorf("unable to unmarshal event: %w", err)
 	}
-	body := data.Body
 	if body.Error != nil {
 		log.Printf("event body has error, skipping: %+v", body.Error)
 		return "", nil

--- a/image-copy-gcr/cmd/app/main.go
+++ b/image-copy-gcr/cmd/app/main.go
@@ -68,13 +68,12 @@ func main() {
 			return nil
 		}
 
-		data := events.Occurrence{Body: registry.PushEvent{}}
+		body := &registry.PushEvent{}
+		data := events.Occurrence{Body: body}
 		if err := event.DataAs(&data); err != nil {
 			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
-
 		log.Printf("got event: %+v", data)
-		body := data.Body
 		src := "cgr.dev/" + body.Repository
 		dst := env.DstRepo + "/" + filepath.Base(body.Repository)
 		log.Printf("Copying %s to %s...", src, dst)

--- a/image-copy-gcr/cmd/app/main.go
+++ b/image-copy-gcr/cmd/app/main.go
@@ -68,17 +68,13 @@ func main() {
 			return nil
 		}
 
-		data := events.Occurrence{}
+		data := events.Occurrence{Body: registry.PushEvent{}}
 		if err := event.DataAs(&data); err != nil {
-			return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal data: %w", err)
+			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
 
 		log.Printf("got event: %+v", data)
-
-		body, ok := data.Body.(registry.PushEvent)
-		if !ok {
-			return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unexpected event body type: %T", data.Body)
-		}
+		body := data.Body
 		src := "cgr.dev/" + body.Repository
 		dst := env.DstRepo + "/" + filepath.Base(body.Repository)
 		log.Printf("Copying %s to %s...", src, dst)

--- a/image-copy-gcr/cmd/app/main.go
+++ b/image-copy-gcr/cmd/app/main.go
@@ -74,6 +74,7 @@ func main() {
 			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
 		log.Printf("got event: %+v", data)
+
 		src := "cgr.dev/" + body.Repository
 		dst := env.DstRepo + "/" + filepath.Base(body.Repository)
 		log.Printf("Copying %s to %s...", src, dst)

--- a/image-copy-gcr/iac/main.tf
+++ b/image-copy-gcr/iac/main.tf
@@ -78,7 +78,7 @@ resource "google_cloud_run_service" "image-copy" {
         }
         env {
           name  = "DST_REPO"
-          value = "${var.location}-docker.pkg.dev/${var.project_id}/${var.dst_repo}"
+          value = "${var.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.dst-repo.name}"
         }
       }
     }

--- a/jira-issue-opener/cmd/app/main.go
+++ b/jira-issue-opener/cmd/app/main.go
@@ -56,15 +56,11 @@ func main() {
 			return nil
 		}
 
-		data := events.Occurrence{}
+		data := events.Occurrence{Body: policy.ImagePolicyRecord{}}
 		if err := event.DataAs(&data); err != nil {
-			return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal data: %w", err)
+			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
-
-		body, ok := data.Body.(policy.ImagePolicyRecord)
-		if !ok {
-			return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal body: %v", data.Body)
-		}
+		body := data.Body
 		for name, pol := range body.Policies {
 			if pol.Valid {
 				// Not in violation of policy

--- a/jira-issue-opener/cmd/app/main.go
+++ b/jira-issue-opener/cmd/app/main.go
@@ -56,11 +56,11 @@ func main() {
 			return nil
 		}
 
-		data := events.Occurrence{Body: policy.ImagePolicyRecord{}}
+		body := &policy.ImagePolicyRecord{}
+		data := events.Occurrence{Body: body}
 		if err := event.DataAs(&data); err != nil {
 			return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 		}
-		body := data.Body
 		for name, pol := range body.Policies {
 			if pol.Valid {
 				// Not in violation of policy

--- a/slack-webhook/cmd/app/main.go
+++ b/slack-webhook/cmd/app/main.go
@@ -69,7 +69,7 @@ func main() {
 				Body: &ipr,
 			}
 			if err := event.DataAs(&occ); err != nil {
-				return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal data: %w", err)
+				return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 			}
 			log.Printf("Image Policy Cluster ID: %v", ipr.ClusterID)
 
@@ -85,7 +85,7 @@ func main() {
 				Body: &admission,
 			}
 			if err := event.DataAs(&occ); err != nil {
-				return cloudevents.NewHTTPResult(http.StatusInternalServerError, "unable to unmarshal data: %w", err)
+				return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 			}
 			log.Printf("Response Message %v", admission.Response.Result.Message)
 

--- a/slack-webhook/cmd/app/main.go
+++ b/slack-webhook/cmd/app/main.go
@@ -64,10 +64,8 @@ func main() {
 
 		switch EventType := event.Type(); EventType {
 		case policy.ChangedEventType:
-			var ipr = policy.ImagePolicyRecord{}
-			occ := events.Occurrence{
-				Body: &ipr,
-			}
+			ipr := policy.ImagePolicyRecord{}
+			occ := events.Occurrence{Body: &ipr}
 			if err := event.DataAs(&occ); err != nil {
 				return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 			}
@@ -81,9 +79,7 @@ func main() {
 
 		case admission.ReviewEventType:
 			admission := admissionv1.AdmissionReview{}
-			occ := events.Occurrence{
-				Body: &admission,
-			}
+			occ := events.Occurrence{Body: &admission}
 			if err := event.DataAs(&occ); err != nil {
 				return cloudevents.NewHTTPResult(http.StatusBadRequest, "unable to unmarshal data: %w", err)
 			}


### PR DESCRIPTION
Review comment from #124 

This standardizes on the practice of decoding the `Occurrence` with a typed `Body`, rather than extracting its type as a separate step.

If decoding the `Occurrence` fails, respond with 400 to avoid unnecessary retries.