### PR TITLE
library-copy-aws-code-artifact: add npm mirror to AWS CodeArtifact example

### DIFF
--- a/library-copy-aws-code-artifact/code-artifact-setup.md
+++ b/library-copy-aws-code-artifact/code-artifact-setup.md
@@ -1,0 +1,217 @@
+# AWS CodeArtifact Setup Guide
+
+This guide will help you set up AWS CodeArtifact to test the npm mirroring script.
+
+## Prerequisites
+
+1. **AWS CLI installed**
+   ```bash
+   # Check if installed
+   aws --version
+
+   # If not installed, visit: https://aws.amazon.com/cli/
+   ```
+
+2. **AWS credentials configured**
+   ```bash
+   # Configure AWS CLI with your credentials
+   aws configure
+
+   # Enter:
+   # - AWS Access Key ID
+   # - AWS Secret Access Key
+   # - Default region (e.g., us-east-1)
+   # - Default output format (json)
+   ```
+
+3. **Chainguard credentials**
+   - You need a Chainguard account with access to Chainguard Libraries
+   - Get your authentication token from Chainguard
+
+## Quick Setup
+
+### Option 1: Automated Setup (Recommended)
+
+Use the provided setup script:
+
+```bash
+# Make it executable
+chmod +x setup-codeartifact.sh
+
+# Run the setup
+./setup-codeartifact.sh
+```
+
+The script will:
+- Create a CodeArtifact domain named `npm-mirror-test`
+- Create a repository named `cg-npm-packages`
+- Display the environment variables you need to export
+
+### Option 2: Manual Setup
+
+If you prefer to set it up manually:
+
+```bash
+# Set your region
+export AWS_REGION="us-east-1"
+
+# Create a CodeArtifact domain
+aws codeartifact create-domain \
+  --domain npm-mirror-test \
+  --region $AWS_REGION
+
+# Create a repository
+aws codeartifact create-repository \
+  --domain npm-mirror-test \
+  --repository cg-npm-packages \
+  --description "npm packages mirror from Chainguard" \
+  --region $AWS_REGION
+```
+
+## Configure Environment Variables
+
+After setup, export these environment variables:
+
+```bash
+# AWS CodeArtifact settings
+export AWS_REGION="us-east-1"
+export CODEARTIFACT_DOMAIN="npm-mirror-test"
+export CODEARTIFACT_REPOSITORY="cg-npm-packages"
+# CODEARTIFACT_DOMAIN_OWNER is optional - will auto-detect your AWS account ID
+
+# Chainguard credentials
+export CGR_USER="your-chainguard-identity"
+export CGR_TOKEN="your-chainguard-token"
+```
+
+## Test the Mirror Script
+
+### 1. Create a test package-lock.json
+
+Create a simple test project:
+
+```bash
+# Create test directory
+mkdir test-mirror
+cd test-mirror
+
+# Initialize npm project
+npm init -y
+
+# Install a small package to generate package-lock.json
+npm install lodash@4.17.21
+```
+
+### 2. Run the mirror script
+
+```bash
+# Run the mirror script from the code-artifact directory
+cd ../code-artifact
+./npm-codeartifact-mirror.sh ../test-mirror/package-lock.json
+```
+
+### 3. Verify packages in CodeArtifact
+
+```bash
+# List packages in your repository
+aws codeartifact list-packages \
+  --domain npm-mirror-test \
+  --repository cg-npm-packages \
+  --format npm \
+  --region $AWS_REGION
+
+# List versions of a specific package
+aws codeartifact list-package-versions \
+  --domain npm-mirror-test \
+  --repository cg-npm-packages \
+  --format npm \
+  --package lodash \
+  --region $AWS_REGION
+
+# For scoped packages, use the --namespace parameter
+aws codeartifact list-package-versions \
+  --domain npm-mirror-test \
+  --repository cg-npm-packages \
+  --format npm \
+  --package fs-minipass \
+  --namespace isaacs \
+  --region $AWS_REGION
+```
+
+## Features
+
+The mirroring script supports:
+- **Regular npm packages** (e.g., `lodash`, `express`)
+- **Scoped packages** (e.g., `@types/node`, `@babel/core`, `@isaacs/fs-minipass`)
+- **Duplicate detection** - skips packages already in CodeArtifact
+- **Attestation preservation** - npm package attestations are preserved during mirroring
+
+## Test npm install from CodeArtifact
+
+Configure npm to use your CodeArtifact repository:
+
+```bash
+# Get auth token
+export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+  --domain npm-mirror-test \
+  --query authorizationToken \
+  --output text \
+  --region $AWS_REGION)
+
+# Get repository endpoint
+export CODEARTIFACT_REGISTRY=$(aws codeartifact get-repository-endpoint \
+  --domain npm-mirror-test \
+  --repository cg-npm-packages \
+  --format npm \
+  --query repositoryEndpoint \
+  --output text \
+  --region $AWS_REGION)
+
+# Configure npm to use CodeArtifact
+npm config set registry $CODEARTIFACT_REGISTRY
+npm config set //$(echo $CODEARTIFACT_REGISTRY | sed 's|https://||')/:_authToken $CODEARTIFACT_AUTH_TOKEN
+
+# Test install
+npm install lodash
+```
+
+## Cleanup (Optional)
+
+When you're done testing:
+
+```bash
+# Delete the repository
+aws codeartifact delete-repository \
+  --domain npm-mirror-test \
+  --repository cg-npm-packages \
+  --region $AWS_REGION
+
+# Delete the domain
+aws codeartifact delete-domain \
+  --domain npm-mirror-test \
+  --region $AWS_REGION
+```
+
+## Troubleshooting
+
+### "Access Denied" errors
+- Ensure your AWS IAM user/role has CodeArtifact permissions
+- Required permissions: `codeartifact:*`, `sts:GetServiceBearerToken`
+
+### "Package not found" in Chainguard
+- Not all npm packages are available in Chainguard Libraries
+- Chainguard curates packages for security
+- Check the Chainguard catalog for available packages
+
+### Authentication failures
+- CodeArtifact tokens expire after 12 hours
+- Re-run the auth token command if needed
+- Ensure Chainguard credentials are correct
+
+## Cost Considerations
+
+AWS CodeArtifact pricing (as of 2024):
+- **Storage**: $0.05 per GB per month
+- **Requests**: $0.05 per 10,000 requests
+
+For testing with a few packages, costs should be minimal (typically < $1/month).

--- a/library-copy-aws-code-artifact/npm-codeartifact-mirror.sh
+++ b/library-copy-aws-code-artifact/npm-codeartifact-mirror.sh
@@ -1,0 +1,626 @@
+#!/bin/bash
+
+# npm-codeartifact-mirror.sh
+# Mirrors npm packages from Chainguard Libraries to AWS CodeArtifact
+# This script reads package-lock.json or pnpm-lock.yaml, checks availability in
+# Chainguard Libraries, downloads packages with proper authentication, and publishes
+# them to CodeArtifact.
+#
+# DISCLAIMER:
+# This script is provided as an example without warranty of any kind, either expressed
+# or implied, including but not limited to the implied warranties of merchantability
+# and fitness for a particular purpose. Use at your own risk. No support is provided.
+#
+# Usage: ./npm-codeartifact-mirror.sh [path-to-lock-file]
+#   Supports package-lock.json (npm) and pnpm-lock.yaml (pnpm)
+#   Auto-detects the lock file if no argument is provided
+
+set -e
+
+# Configuration
+CHAINGUARD_REGISTRY="https://libraries.cgr.dev/javascript/"
+TEMP_DIR="${TEMP_DIR:-./temp_packages}"
+LOG_FILE="${LOG_FILE:-./mirror.log}"
+NPM_CONFIG_CHAINGUARD=".npmrc.chainguard"
+NPM_CONFIG_CODEARTIFACT=".npmrc.codeartifact"
+
+# npm transport robustness. These handle TRANSIENT failures (network blips,
+# socket timeouts, 429/5xx) — note they do NOT retry 404/ETARGET, which npm
+# treats as definitive; that case is handled by the multi-pass retry loop in
+# process_packages instead.
+NPM_FETCH_RETRIES="${NPM_FETCH_RETRIES:-5}"
+NPM_FETCH_TIMEOUT="${NPM_FETCH_TIMEOUT:-60000}"
+
+# Required environment variables (set these before running)
+# CGR_USER - Chainguard user/identity
+# CGR_TOKEN - Chainguard authentication token
+# AWS_REGION (e.g., us-east-1)
+# CODEARTIFACT_DOMAIN
+# CODEARTIFACT_REPOSITORY
+# CODEARTIFACT_DOMAIN_OWNER (optional, will use AWS account ID if not set)
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log() {
+    echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1" | tee -a "$LOG_FILE"
+}
+
+warn() {
+    echo -e "${YELLOW}[$(date +'%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1" | tee -a "$LOG_FILE"
+}
+
+error() {
+    echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" | tee -a "$LOG_FILE"
+}
+
+# Check required environment variables
+check_env() {
+    local missing=0
+
+    if [ -z "$CGR_USER" ]; then
+        error "CGR_USER is not set"
+        missing=1
+    fi
+
+    if [ -z "$CGR_TOKEN" ]; then
+        error "CGR_TOKEN is not set"
+        missing=1
+    fi
+
+    if [ -z "$AWS_REGION" ]; then
+        error "AWS_REGION is not set"
+        missing=1
+    fi
+
+    if [ -z "$CODEARTIFACT_DOMAIN" ]; then
+        error "CODEARTIFACT_DOMAIN is not set"
+        missing=1
+    fi
+
+    if [ -z "$CODEARTIFACT_REPOSITORY" ]; then
+        error "CODEARTIFACT_REPOSITORY is not set"
+        missing=1
+    fi
+
+    if [ $missing -eq 1 ]; then
+        error "Missing required environment variables. Please set them and try again."
+        exit 1
+    fi
+
+    log "Environment variables validated"
+}
+
+# Setup authentication for Chainguard registry
+setup_chainguard_auth() {
+    log "Setting up Chainguard registry authentication..."
+
+    # Create base64 encoded token for direct API calls
+    export CHAINGUARD_AUTH_TOKEN=$(echo -n "${CGR_USER}:${CGR_TOKEN}" | base64)
+
+    # Configure npm to use Chainguard registry for downloads (in local .npmrc)
+    local cgr_host=$(echo "$CHAINGUARD_REGISTRY" | sed 's|^http://||' | sed 's|^https://||' | sed 's|/.*$||')
+    local cgr_path=$(echo "$CHAINGUARD_REGISTRY" | sed 's|^http://[^/]*||' | sed 's|^https://[^/]*||')
+
+    # Create Chainguard npm config file in temp directory
+    mkdir -p "$TEMP_DIR"
+    echo "//${cgr_host}${cgr_path}:_auth=$CHAINGUARD_AUTH_TOKEN" > "${TEMP_DIR}/${NPM_CONFIG_CHAINGUARD}"
+
+    log "Chainguard authentication configured"
+}
+
+# Setup authentication for CodeArtifact
+setup_codeartifact_auth() {
+    log "Setting up AWS CodeArtifact authentication..."
+
+    # Get domain owner (AWS account ID) if not provided
+    if [ -z "$CODEARTIFACT_DOMAIN_OWNER" ]; then
+        CODEARTIFACT_DOMAIN_OWNER=$(aws sts get-caller-identity --query Account --output text)
+        log "Using AWS account ID: $CODEARTIFACT_DOMAIN_OWNER"
+    fi
+
+    # Get CodeArtifact auth token
+    local ca_token=$(aws codeartifact get-authorization-token \
+        --domain "$CODEARTIFACT_DOMAIN" \
+        --domain-owner "$CODEARTIFACT_DOMAIN_OWNER" \
+        --region "$AWS_REGION" \
+        --query authorizationToken \
+        --output text)
+
+    if [ -z "$ca_token" ]; then
+        error "Failed to get CodeArtifact authorization token"
+        exit 1
+    fi
+
+    # Get CodeArtifact repository endpoint
+    export CODEARTIFACT_REGISTRY=$(aws codeartifact get-repository-endpoint \
+        --domain "$CODEARTIFACT_DOMAIN" \
+        --domain-owner "$CODEARTIFACT_DOMAIN_OWNER" \
+        --repository "$CODEARTIFACT_REPOSITORY" \
+        --format npm \
+        --region "$AWS_REGION" \
+        --query repositoryEndpoint \
+        --output text)
+
+    if [ -z "$CODEARTIFACT_REGISTRY" ]; then
+        error "Failed to get CodeArtifact repository endpoint"
+        exit 1
+    fi
+
+    # Create CodeArtifact npm config file in temp directory
+    # Extract registry URL without protocol, keep trailing slash
+    local ca_registry_path=$(echo "$CODEARTIFACT_REGISTRY" | sed 's|^http://||' | sed 's|^https://||')
+    # Ensure exactly one trailing slash before the colon
+    ca_registry_path=$(echo "$ca_registry_path" | sed 's|/*$|/|')
+    echo "//${ca_registry_path}:_authToken=$ca_token" > "${TEMP_DIR}/${NPM_CONFIG_CODEARTIFACT}"
+
+    log "CodeArtifact authentication configured"
+    log "CodeArtifact registry: $CODEARTIFACT_REGISTRY"
+}
+
+# Check if a specific package version already exists in CodeArtifact.
+check_package_in_codeartifact() {
+    local package_name=$1
+    local version=$2
+
+    # CodeArtifact stores an npm scope as a separate namespace.
+    local ns_args=()
+    local pkg="$package_name"
+    if [[ "$package_name" == @*/* ]]; then
+        local scope="${package_name%%/*}"
+        scope="${scope#@}"
+        pkg="${package_name#*/}"
+        ns_args=(--namespace "$scope")
+    fi
+
+    if aws codeartifact describe-package-version \
+        --domain "$CODEARTIFACT_DOMAIN" \
+        --domain-owner "$CODEARTIFACT_DOMAIN_OWNER" \
+        --repository "$CODEARTIFACT_REPOSITORY" \
+        --format npm \
+        "${ns_args[@]}" \
+        --package "$pkg" \
+        --package-version "$version" \
+        --region "$AWS_REGION" \
+        --output text > /dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Download a package from the Chainguard registry via `npm pack`.
+# Return codes let the caller react to the specific npm failure:
+#   0 = downloaded (tarball path on stdout)
+#   2 = ETARGET (version not currently served)
+#   3 = 404 (package/version not currently served)
+#   4 = auth/permission error (401/403)
+#   1 = other failure (network, tarball-name mismatch, etc.)
+# Codes 2 and 3 are usually transient: Chainguard ingests upstream packages on
+# demand, so a retry after a short wait typically succeeds (see process_packages).
+download_package_from_chainguard() {
+    local package_name=$1
+    local version=$2
+    local output_dir=$3
+    local prefer_online=$4   # non-empty -> add --prefer-online (used on retry passes)
+
+    log "Downloading ${package_name}@${version}..." >&2
+
+    cd "$output_dir" || return 1
+
+    # --prefer-online revalidates cached metadata (registry sends max-age=300),
+    # so retry passes see freshly-ingested versions instead of a stale packument.
+    local online_flag=()
+    [ -n "$prefer_online" ] && online_flag=(--prefer-online)
+
+    # Capture npm's output so we can classify the failure reason.
+    local npm_output
+    npm_output=$(npm pack "${package_name}@${version}" \
+        --registry="${CHAINGUARD_REGISTRY}" \
+        --userconfig="$NPM_CONFIG_CHAINGUARD" \
+        --fetch-retries="$NPM_FETCH_RETRIES" \
+        --fetch-timeout="$NPM_FETCH_TIMEOUT" \
+        "${online_flag[@]}" 2>&1)
+    local npm_exit=$?
+
+    cd - > /dev/null || return 1
+
+    # If npm pack succeeded, find the tarball that was created
+    if [ $npm_exit -eq 0 ]; then
+        # The tarball name follows the pattern: packagename-version.tgz
+        # For scoped packages: @scope/packagename becomes scope-packagename
+        local expected_name=$(echo "${package_name}" | sed 's/@//' | sed 's/\//-/')
+        local tarball_path="${output_dir}/${expected_name}-${version}.tgz"
+
+        if [ -f "$tarball_path" ]; then
+            echo "$tarball_path"
+            return 0
+        fi
+        warn "Package ${package_name}@${version}: npm pack succeeded but tarball not found at expected path" >&2
+        return 1
+    fi
+
+    # Classify the npm failure so the caller can retry transient ones (2/3).
+    if echo "$npm_output" | grep -q 'code ETARGET'; then
+        warn "${package_name}@${version}: not yet available (ETARGET)" >&2
+        return 2
+    elif echo "$npm_output" | grep -Eq 'code E404|404 Not Found'; then
+        warn "${package_name}@${version}: not yet available (404)" >&2
+        return 3
+    elif echo "$npm_output" | grep -Eq 'code E401|code E403|EAUTHUNKNOWN|Unauthorized|Forbidden'; then
+        error "${package_name}@${version}: auth/permission error from Chainguard" >&2
+        return 4
+    else
+        warn "${package_name}@${version}: npm pack failed: $(echo "$npm_output" | grep -m1 'npm error' || echo 'unknown error')" >&2
+        return 1
+    fi
+}
+
+# Publish package to CodeArtifact
+publish_to_codeartifact() {
+    local tarball_file=$1
+    local package_name=$2
+    local version=$3
+
+    log "Publishing ${package_name}@${version} to CodeArtifact..."
+
+    # Verify tarball exists
+    if [ ! -f "$tarball_file" ]; then
+        error "Tarball file not found: $tarball_file"
+        return 1
+    fi
+
+    # Publish tarball directly to CodeArtifact
+    local publish_output=$(npm publish "$tarball_file" \
+        --registry="$CODEARTIFACT_REGISTRY" \
+        --userconfig="${TEMP_DIR}/${NPM_CONFIG_CODEARTIFACT}" \
+        --fetch-retries="$NPM_FETCH_RETRIES" \
+        --fetch-timeout="$NPM_FETCH_TIMEOUT" 2>&1)
+    local exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        log "Successfully published ${package_name}@${version}"
+        return 0
+    else
+        error "Failed to publish ${package_name}@${version}: $publish_output"
+        return 1
+    fi
+}
+
+# Extract packages from package-lock.json (npm)
+extract_packages_npm() {
+    local lock_file=$1
+
+    log "Parsing package-lock.json..." >&2
+
+    # Output format: NAME|VERSION (using | as delimiter to handle scoped packages with @)
+    jq -r '
+        .packages // {} |
+        to_entries[] |
+        select(.key != "") |
+        select(.value.version != null) |
+        {
+            path: .key,
+            name: (if (.value.name != null) then .value.name else (.key | split("node_modules/") | last) end),
+            version: .value.version
+        } |
+        "\(.name)|\(.version)"
+    ' "$lock_file" | sort -u
+}
+
+# Extract packages from a pnpm lockfile (pnpm-lock.yaml / package-lock.yaml)
+#
+# Unlike npm, pnpm stores a package's identity in the map KEY as name@version
+# (there are no separate name/version fields), and the key format varies by
+# lockfileVersion:
+#   v9: "name@version"            / "@scope/name@version"
+#   v6: "/name@version"           (leading slash; peer deps as "(dep@1.0.0)")
+#   v5: "/name/version"           (slash separator, no @ before version)
+# We convert the .packages map to JSON once and normalize all three shapes in
+# jq, so the result is identical regardless of which pnpm wrote the lockfile.
+extract_packages_pnpm() {
+    local lock_file=$1
+
+    log "Parsing pnpm lockfile (YAML)..." >&2
+
+    # How many packages does the lockfile claim to have?
+    local pkg_count
+    pkg_count=$(yq e '.packages | length' "$lock_file" 2>/dev/null)
+    [ -z "$pkg_count" ] && pkg_count=0
+
+    local extracted
+    extracted=$(yq -o=json '.packages // {}' "$lock_file" | jq -r '
+        keys[]
+        | sub("^/"; "")                       # v6: strip leading slash
+        | sub("\\(.*$"; "")                   # strip "(peer@x)" suffix
+        | . as $k
+        | (ltrimstr("@") | test("@")) as $hasAt   # ignore a leading scope "@"
+        | (if $hasAt
+             then ($k | capture("^(?<name>.+)@(?<version>[^@]+)$"))   # v6/v9
+             else ($k | capture("^(?<name>.+)/(?<version>[^/]+)$"))   # v5
+           end)
+        | select(.name != "" and .version != "")
+        | select(.version | test("://") | not)   # drop tarball/git "versions"
+        | "\(.name)|\(.version)"
+    ' | sort -u)
+
+    local extracted_count=0
+    [ -n "$extracted" ] && extracted_count=$(printf '%s\n' "$extracted" | grep -c '|')
+
+    # Fail loud: a populated lockfile that yields nothing is a tooling/format
+    # mismatch (wrong yq flavor, unsupported lockfileVersion) — NOT "nothing to
+    # mirror". Silently reporting 0 here is the bug we're guarding against.
+    # NOTE: this exit only aborts the script because process_packages captures
+    # our output in the main shell (see the call site), not via a subshell.
+    if [ "$pkg_count" -gt 0 ] && [ "$extracted_count" -eq 0 ]; then
+        error "Lockfile lists ${pkg_count} packages but extraction produced none." >&2
+        error "Verify yq is the mikefarah build (v4) and the lockfileVersion is supported." >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$extracted"
+}
+
+# Extract packages — dispatches to the right parser based on file extension
+extract_packages() {
+    local lock_file=$1
+
+    if [ ! -f "$lock_file" ]; then
+        error "Lock file not found at: $lock_file"
+        exit 1
+    fi
+
+    case "$lock_file" in
+        *.yaml|*.yml)
+            extract_packages_pnpm "$lock_file"
+            ;;
+        *)
+            extract_packages_npm "$lock_file"
+            ;;
+    esac
+}
+
+
+# Main processing function
+process_packages() {
+    local lock_file=$1
+    local temp_dir=$2
+
+    mkdir -p "$temp_dir"
+
+    local downloaded=0
+    local published=0
+    local already_exists=0
+    local failed=0
+    # Final breakdown of packages still unavailable after all retry passes.
+    local version_gap=0
+    local pkg_missing=0
+    local auth_err=0
+    local other_fail=0
+    local unresolved=""   # "REASON<tab>name@version" lines for the report
+
+    # Chainguard's upstream fallback ingests packages ON DEMAND and
+    # ASYNCHRONOUSLY, so the first request for an un-cached package/version returns
+    # 404/ETARGET while Chainguard fetches it from npm in the background, and it
+    # becomes downloadable moments later. A single npm pack call works too fast for this process. 
+    # Accordingly, make multiple passes where the first pass primes ingestion for every miss, and 
+    # subsequent passes (after a short wait) pick up the now-populated packages. Tunable via env vars.
+    local max_passes="${INGEST_MAX_PASSES:-4}"
+    local retry_delay="${INGEST_RETRY_DELAY:-30}"
+
+    # Extract into a variable in THIS shell first. Capturing here (rather than
+    # feeding the loop via process substitution) lets a fail-loud exit inside
+    # extract_packages abort the whole run under `set -e`, instead of dying
+    # silently in a subshell and leaving the loop to report 0.
+    local pkg_list
+    pkg_list=$(extract_packages "$lock_file")
+    local total
+    total=$(printf '%s\n' "$pkg_list" | grep -c '|' || true)
+
+    # Work queue. First pass holds "name|version"; retry passes hold
+    # "rc|name|version" so each miss carries its last classification forward.
+    local pending="$pkg_list"
+    local pass=0
+
+    while [ -n "$(printf '%s' "$pending" | tr -d '[:space:]')" ] && [ "$pass" -lt "$max_passes" ]; do
+        pass=$((pass + 1))
+        local is_first=0; [ "$pass" -eq 1 ] && is_first=1
+        local count_this; count_this=$(printf '%s\n' "$pending" | grep -c '|' || true)
+        log "=== Pass ${pass}/${max_passes}: attempting ${count_this} package(s) ==="
+        local next_pending=""
+
+        while IFS='|' read -r f1 f2 f3; do
+            local package_name package_version
+            if [ "$is_first" -eq 1 ]; then
+                package_name="$f1"; package_version="$f2"
+            else
+                package_name="$f2"; package_version="$f3"   # f1 is the carried rc
+            fi
+            [ -z "$package_name" ] && continue
+
+            # Only check CodeArtifact (and count already-exists) on the first pass;
+            # retry queue only ever holds packages we already know aren't there.
+            if [ "$is_first" -eq 1 ]; then
+                log "Processing ${package_name}@${package_version}..."
+                if check_package_in_codeartifact "$package_name" "$package_version"; then
+                    log "${package_name}@${package_version} already exists in CodeArtifact, skipping"
+                    already_exists=$((already_exists + 1))
+                    continue
+                fi
+            else
+                log "Retry ${package_name}@${package_version}..."
+            fi
+
+            # On retry passes, force fresh metadata (--prefer-online) so the
+            # registry's 5-minute packument cache doesn't keep returning ETARGET
+            # for a version that has since been ingested.
+            local prefer_online=""
+            [ "$is_first" -eq 0 ] && prefer_online="1"
+
+            # `&& rc=0 || rc=$?` keeps this in a tested context so a non-zero
+            # return doesn't trip `set -e`.
+            local tarball_file rc
+            tarball_file=$(download_package_from_chainguard "$package_name" "$package_version" "$temp_dir" "$prefer_online") && rc=0 || rc=$?
+
+            case $rc in
+                0)
+                    downloaded=$((downloaded + 1))
+                    if publish_to_codeartifact "$tarball_file" "$package_name" "$package_version"; then
+                        published=$((published + 1))
+                        rm -f "$tarball_file"
+                    else
+                        failed=$((failed + 1))
+                        unresolved+="PUBLISH"$'\t'"${package_name}@${package_version}"$'\n'
+                    fi
+                    ;;
+                4)  # auth won't resolve by retrying — record now, don't re-queue
+                    auth_err=$((auth_err + 1))
+                    unresolved+="AUTH"$'\t'"${package_name}@${package_version}"$'\n'
+                    ;;
+                *)
+                    # 1/2/3: not served yet — may still be ingesting. Re-queue,
+                    # carrying the rc so we can classify it if it never resolves.
+                    next_pending+="${rc}|${package_name}|${package_version}"$'\n'
+                    ;;
+            esac
+        done <<< "$pending"
+
+        pending="$next_pending"
+        local remaining; remaining=$(printf '%s\n' "$pending" | grep -c '|' || true)
+        if [ "$remaining" -gt 0 ] && [ "$pass" -lt "$max_passes" ]; then
+            log "Pass ${pass} done; ${remaining} still unavailable — waiting ${retry_delay}s for Chainguard fallback to ingest, then retrying..."
+            sleep "$retry_delay"
+        fi
+    done
+
+    # Whatever is still pending after the final pass is genuinely unavailable
+    # (truly nonexistent, malware-blocked, still in cooldown, or no verifiable
+    # source). Classify by the last rc each carried.
+    while IFS='|' read -r rc package_name package_version; do
+        [ -z "$package_name" ] && continue
+        case $rc in
+            2) version_gap=$((version_gap + 1)); unresolved+="ETARGET"$'\t'"${package_name}@${package_version}"$'\n' ;;
+            3) pkg_missing=$((pkg_missing + 1));  unresolved+="404"$'\t'"${package_name}@${package_version}"$'\n' ;;
+            *) other_fail=$((other_fail + 1));    unresolved+="OTHER"$'\t'"${package_name}@${package_version}"$'\n' ;;
+        esac
+    done <<< "$pending"
+
+    # Summary
+    local not_mirrored=$((version_gap + pkg_missing + auth_err + other_fail))
+    log "=========================================="
+    log "Mirror Summary:"
+    log "  Total packages:                 $total"
+    log "  Already in CodeArtifact:        $already_exists"
+    log "  Downloaded from Chainguard:     $downloaded"
+    log "  Published to CodeArtifact:      $published"
+    log "  Unavailable after ${max_passes} passes:  $not_mirrored"
+    log "    - ETARGET (version still not served):   $version_gap"
+    log "    - 404 (still not served):               $pkg_missing"
+    log "    - Auth/permission errors:               $auth_err"
+    log "    - Other failures:                       $other_fail"
+    log "  Publish failures:               $failed"
+    log "=========================================="
+    if [ -n "$unresolved" ]; then
+        local report="${UNRESOLVED_REPORT:-./chainguard-unresolved.txt}"
+        printf '%s' "$unresolved" | sort > "$report"
+        log "Unresolved packages (reason<tab>name@version) written to: $report"
+    fi
+    if [ "$not_mirrored" -gt 0 ]; then
+        log "NOTE: still unavailable after ${max_passes} passes — likely within the cooldown"
+        log "window, malware-blocked, no verifiable source, or nonexistent. Re-running"
+        log "later may pick up packages past cooldown. Tune: INGEST_MAX_PASSES / INGEST_RETRY_DELAY."
+    fi
+}
+
+# Main script execution
+main() {
+    # Parse command line arguments
+    if [ $# -gt 0 ]; then
+        PACKAGE_LOCK_FILE="$1"
+    elif [ -n "$PACKAGE_LOCK_FILE" ]; then
+        : # Use value from environment
+    elif [ -f "./package-lock.json" ]; then
+        PACKAGE_LOCK_FILE="./package-lock.json"
+    elif [ -f "./pnpm-lock.yaml" ]; then
+        PACKAGE_LOCK_FILE="./pnpm-lock.yaml"
+    else
+        PACKAGE_LOCK_FILE="./package-lock.json"
+    fi
+
+    log "Starting npm package mirror to AWS CodeArtifact..."
+    log "Package lock file: $PACKAGE_LOCK_FILE"
+    log "Chainguard registry: $CHAINGUARD_REGISTRY"
+
+    # Check if lock file exists
+    if [ ! -f "$PACKAGE_LOCK_FILE" ]; then
+        error "Lock file not found: $PACKAGE_LOCK_FILE"
+        echo ""
+        echo "Usage: $0 [path-to-lock-file]"
+        echo ""
+        echo "Examples:"
+        echo "  $0                              # Auto-detects package-lock.json or pnpm-lock.yaml"
+        echo "  $0 /path/to/package-lock.json  # Uses npm lock file"
+        echo "  $0 /path/to/pnpm-lock.yaml     # Uses pnpm lock file"
+        exit 1
+    fi
+
+    # Check prerequisites
+    if ! command -v jq &> /dev/null; then
+        error "jq is required but not installed. Please install jq and try again."
+        exit 1
+    fi
+
+    # yq is required for pnpm lockfiles — and it MUST be the Go (mikefarah) v4
+    # build. The Python (kislyuk) yq uses different argument semantics, so
+    # `yq e '...'` silently parses nothing and the run reports 0 packages.
+    case "$PACKAGE_LOCK_FILE" in
+        *.yaml|*.yml)
+            if ! command -v yq &> /dev/null; then
+                error "yq is required for pnpm lockfiles but not installed. Install mikefarah yq v4 (e.g. brew install yq)."
+                exit 1
+            fi
+            if ! yq --version 2>&1 | grep -qi 'mikefarah'; then
+                error "Wrong yq detected — this script needs the Go 'mikefarah' yq v4, not the Python (kislyuk) yq."
+                error "Found: $(yq --version 2>&1). Install the correct one with: brew install yq"
+                exit 1
+            fi
+            ;;
+    esac
+
+    if ! command -v curl &> /dev/null; then
+        error "curl is required but not installed. Please install curl and try again."
+        exit 1
+    fi
+
+    if ! command -v npm &> /dev/null; then
+        error "npm is required but not installed. Please install npm and try again."
+        exit 1
+    fi
+
+    if ! command -v aws &> /dev/null; then
+        error "AWS CLI is required but not installed. Please install aws-cli and try again."
+        exit 1
+    fi
+
+    # Validate environment
+    check_env
+
+    # Setup authentication
+    setup_chainguard_auth
+    setup_codeartifact_auth
+
+    # Process packages
+    process_packages "$PACKAGE_LOCK_FILE" "$TEMP_DIR"
+
+    # Cleanup
+    rmdir "$TEMP_DIR" 2>/dev/null || true
+
+    log "Mirror process completed!"
+}
+
+# Run main function
+main "$@"

--- a/library-copy-aws-code-artifact/npm-codeartifact-mirror.sh
+++ b/library-copy-aws-code-artifact/npm-codeartifact-mirror.sh
@@ -39,23 +39,17 @@ NPM_FETCH_TIMEOUT="${NPM_FETCH_TIMEOUT:-60000}"
 # CODEARTIFACT_REPOSITORY
 # CODEARTIFACT_DOMAIN_OWNER (optional, will use AWS account ID if not set)
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
 # Logging functions
 log() {
-    echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1" | tee -a "$LOG_FILE"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
 }
 
 warn() {
-    echo -e "${YELLOW}[$(date +'%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1" | tee -a "$LOG_FILE"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] WARNING: $1" | tee -a "$LOG_FILE"
 }
 
 error() {
-    echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" | tee -a "$LOG_FILE"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] ERROR: $1" | tee -a "$LOG_FILE"
 }
 
 # Check required environment variables
@@ -200,8 +194,6 @@ check_package_in_codeartifact() {
 #   3 = 404 (package/version not currently served)
 #   4 = auth/permission error (401/403)
 #   1 = other failure (network, tarball-name mismatch, etc.)
-# Codes 2 and 3 are usually transient: Chainguard ingests upstream packages on
-# demand, so a retry after a short wait typically succeeds (see process_packages).
 download_package_from_chainguard() {
     local package_name=$1
     local version=$2

--- a/library-copy-aws-code-artifact/readme.md
+++ b/library-copy-aws-code-artifact/readme.md
@@ -1,0 +1,364 @@
+# npm-codeartifact-mirror.sh
+
+A bash script that mirrors npm packages from Chainguard Libraries to AWS CodeArtifact. This tool reads an npm `package-lock.json` **or** a pnpm `pnpm-lock.yaml` lockfile, downloads each package from Chainguard's curated npm registry (with fallback to public npm), and publishes them to your private CodeArtifact repository.
+
+If you need to set up code artifact, refer to [code-artifact-setup.md](code-artifact-setup.md).
+
+## Overview
+
+This script automates the process of:
+1. Parsing a lockfile to extract all package dependencies (ensure your lockfile has all dependencies and transitives defined, which is the standard behavior if `npm install` / `pnpm install` was run to create it).
+2. Checking if packages already exist in CodeArtifact (to avoid duplicates)
+3. Downloading packages from Chainguard Libraries registry
+4. Publishing packages to AWS CodeArtifact
+5. Retrying packages that Chainguard has not yet ingested, across multiple passes
+6. Writing a report of anything that remained unavailable
+
+The script handles both regular and scoped packages (e.g., `@types/node`, `@isaacs/fs-minipass`).
+
+### Supported lockfiles
+
+| Lockfile | Tool | Parser | Notes |
+|----------|------|--------|-------|
+| `package-lock.json` | npm | `jq` | Reads the `.packages` map |
+| `pnpm-lock.yaml` / `*.yaml` / `*.yml` | pnpm | `yq` + `jq` | Supports lockfileVersion v5, v6, and v9 key formats |
+
+The parser is chosen automatically from the file extension (`.yaml`/`.yml` → pnpm, anything else → npm).
+
+## Disclaimer
+
+This script is provided as an example without warranty of any kind, either expressed or implied, including but not limited to the implied warranties of merchantability and fitness for a particular purpose. Use at your own risk. No support is provided.
+
+## Prerequisites
+
+Before running this script, ensure you have the following tools installed:
+
+- **jq** - JSON processor for parsing lockfiles
+- **yq** - YAML processor, **required only for pnpm lockfiles**. Must be the Go [mikefarah](https://github.com/mikefarah/yq) build (v4), *not* the Python (kislyuk) `yq` — the script verifies this and aborts if the wrong one is found.
+- **curl** - HTTP client
+- **npm** - Node package manager (used for `npm pack` / `npm publish`)
+- **aws-cli** - AWS Command Line Interface
+- **bash** - Unix shell (version 4.0 or higher recommended)
+
+### Installation Examples
+
+```bash
+# macOS (using Homebrew)
+brew install jq yq awscli node
+```
+
+## Required Environment Variables
+
+Set these environment variables before running the script:
+
+### Chainguard Registry Authentication
+- `CGR_USER` - Your Chainguard user/identity
+- `CGR_TOKEN` - Your Chainguard authentication token
+
+### AWS CodeArtifact Configuration
+- `AWS_REGION` - AWS region where your CodeArtifact repository is located (e.g., `us-east-1`)
+- `CODEARTIFACT_DOMAIN` - Your CodeArtifact domain name
+- `CODEARTIFACT_REPOSITORY` - Your CodeArtifact repository name
+- `CODEARTIFACT_DOMAIN_OWNER` - (Optional) AWS account ID. If not set, will use your current AWS account
+
+### Optional Configuration
+- `PACKAGE_LOCK_FILE` - Path to the lockfile to mirror. Overridden by a path passed as the first CLI argument; if neither is set the script auto-detects `package-lock.json` then `pnpm-lock.yaml` in the current directory.
+- `TEMP_DIR` - Directory for temporary package downloads (default: `./temp_packages`)
+- `LOG_FILE` - Path to log file (default: `./mirror.log`)
+- `UNRESOLVED_REPORT` - Path for the report of packages that could not be mirrored (default: `./chainguard-unresolved.txt`)
+
+#### Tuning the on-demand ingestion retry
+Chainguard ingests upstream packages **on demand and asynchronously**, so the first request for an un-cached package often returns 404/ETARGET while it is fetched in the background. These variables control the retry behavior (see [How It Works](#how-it-works)):
+
+- `INGEST_MAX_PASSES` - Maximum number of passes over the still-unavailable packages (default: `4`)
+- `INGEST_RETRY_DELAY` - Seconds to wait between passes while Chainguard ingests (default: `30`)
+
+#### Tuning npm transport robustness
+These tune npm's own retry behavior for **transient** transport failures (network blips, socket timeouts, 429/5xx). They do **not** retry 404/ETARGET — that is handled by the multi-pass loop above.
+
+- `NPM_FETCH_RETRIES` - Passed to `npm pack`/`npm publish` as `--fetch-retries` (default: `5`)
+- `NPM_FETCH_TIMEOUT` - Passed as `--fetch-timeout`, in milliseconds (default: `60000`)
+
+### Example Configuration
+
+```bash
+# Chainguard credentials
+export CGR_USER="your-chainguard-user"
+export CGR_TOKEN="your-chainguard-token"
+
+# AWS CodeArtifact settings
+export AWS_REGION="us-east-1"
+export CODEARTIFACT_DOMAIN="my-company"
+export CODEARTIFACT_REPOSITORY="npm-packages"
+export CODEARTIFACT_DOMAIN_OWNER="123456789012"  # Optional
+
+# Optional: Custom paths
+export TEMP_DIR="./temp_packages"
+export LOG_FILE="./mirror.log"
+
+# Optional: tune retries for slow/large mirrors
+export INGEST_MAX_PASSES="6"
+export INGEST_RETRY_DELAY="45"
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Auto-detect package-lock.json or pnpm-lock.yaml in the current directory
+./npm-codeartifact-mirror.sh
+
+# Specify an npm lockfile
+./npm-codeartifact-mirror.sh /path/to/package-lock.json
+
+# Specify a pnpm lockfile
+./npm-codeartifact-mirror.sh /path/to/pnpm-lock.yaml
+```
+
+### Complete Example
+
+```bash
+# 1. Set required environment variables
+export CGR_USER="your-user"
+export CGR_TOKEN="your-token"
+export AWS_REGION="us-east-1"
+export CODEARTIFACT_DOMAIN="my-domain"
+export CODEARTIFACT_REPOSITORY="my-repo"
+
+# 2. Make script executable (if not already)
+chmod +x npm-codeartifact-mirror.sh
+
+# 3. Run the script
+./npm-codeartifact-mirror.sh ./package-lock.json
+```
+
+## How It Works
+
+1. **Prerequisite & environment validation**: Checks that the required CLI tools and environment variables are present. For pnpm lockfiles it also verifies that the `yq` on `PATH` is the mikefarah (Go) v4 build.
+2. **Authentication setup**:
+   - Configures Chainguard registry authentication using provided credentials
+   - Obtains a temporary AWS CodeArtifact authentication token and repository endpoint
+3. **Package parsing**: Extracts all packages and versions from the lockfile (`jq` for npm, `yq` + `jq` for pnpm). If a populated lockfile yields zero packages, the script fails loudly rather than silently reporting "nothing to mirror".
+4. **Multi-pass mirroring**: Chainguard's upstream fallback ingests packages on demand and asynchronously, so a package that 404s on the first request is often downloadable moments later. The script therefore works in passes:
+   - **Pass 1**: For each package, skip it if the version already exists in CodeArtifact; otherwise download it from Chainguard via `npm pack` and publish it to CodeArtifact. Misses (404/ETARGET/transient) are queued for retry. The first request also *primes* Chainguard's ingestion.
+   - **Retry passes**: Wait `INGEST_RETRY_DELAY` seconds, then retry the still-missing packages with `--prefer-online` (to defeat npm's 5-minute packument cache). Repeat up to `INGEST_MAX_PASSES` times.
+   - Auth/permission failures are recorded immediately and **not** retried, since they won't resolve on their own.
+5. **Summary report & unresolved list**: Prints statistics, and if anything could not be mirrored, writes a `reason<tab>name@version` report to `UNRESOLVED_REPORT`.
+
+## Features
+
+### Scoped Package Support
+The script fully supports scoped npm packages (e.g., `@types/node`, `@babel/core`). These are stored in CodeArtifact with separate namespace fields.
+
+### pnpm Lockfile Support
+In addition to npm's `package-lock.json`, the script parses pnpm's `pnpm-lock.yaml`. Because pnpm encodes a package's identity in the map key (and the format differs across lockfileVersion v5/v6/v9), the parser normalizes all three shapes so the result is identical regardless of which pnpm wrote the lockfile.
+
+### Duplicate Prevention
+Before downloading, the script checks if a package version already exists in CodeArtifact to avoid unnecessary downloads and duplicate upload attempts.
+
+### Chainguard Fallback & On-Demand Ingestion Retry
+When using Chainguard Libraries with fallback enabled, packages not already cached in Chainguard's registry are fetched from public npm. Because that ingestion is asynchronous, the first request can fail with 404/ETARGET. The script makes multiple passes (with a configurable delay) so packages that were still ingesting on an earlier pass get picked up once available.
+
+### Failure Classification
+Packages that remain unavailable after all passes are classified in the summary and the unresolved report:
+- **ETARGET** — the requested version is still not served
+- **404** — the package/version is still not served
+- **Auth/permission errors** — 401/403 from Chainguard (not retried)
+- **Other failures** — network or unexpected errors
+- **Publish failures** — downloaded successfully but failed to publish to CodeArtifact
+
+### Transport Robustness
+`npm pack` and `npm publish` are run with configurable `--fetch-retries` and `--fetch-timeout` so transient network/socket/429/5xx errors are retried automatically within npm.
+
+### Attestation Preservation
+- **npm packages**: Standard npm attestations (embedded in tarballs) are preserved during mirroring
+- **Chainguard packages**: Chainguard-specific registry metadata is not preserved, but the packages themselves are functionally identical
+
+## Output and Logging
+
+The script provides color-coded console output and writes detailed logs to the specified log file:
+
+- **Green**: Informational messages
+- **Yellow**: Warnings (e.g., package not yet available in Chainguard)
+- **Red**: Errors
+
+### Example Output
+
+```
+[2026-05-11 10:30:15] Starting npm package mirror to AWS CodeArtifact...
+[2026-05-11 10:30:15] Package lock file: ./package-lock.json
+[2026-05-11 10:30:16] Environment variables validated
+[2026-05-11 10:30:16] Setting up Chainguard registry authentication...
+[2026-05-11 10:30:17] Setting up AWS CodeArtifact authentication...
+[2026-05-11 10:30:18] === Pass 1/4: attempting 41 package(s) ===
+[2026-05-11 10:30:18] Processing express@4.18.2...
+[2026-05-11 10:30:19] Downloading express@4.18.2...
+[2026-05-11 10:30:21] Successfully published express@4.18.2
+...
+[2026-05-11 10:32:05] Pass 1 done; 3 still unavailable — waiting 30s for Chainguard fallback to ingest, then retrying...
+[2026-05-11 10:32:35] === Pass 2/4: attempting 3 package(s) ===
+...
+==========================================
+Mirror Summary:
+  Total packages:                 41
+  Already in CodeArtifact:        5
+  Downloaded from Chainguard:     36
+  Published to CodeArtifact:      36
+  Unavailable after 4 passes:     0
+    - ETARGET (version still not served):   0
+    - 404 (still not served):               0
+    - Auth/permission errors:               0
+    - Other failures:                       0
+  Publish failures:               0
+==========================================
+```
+
+### Unresolved Packages Report
+
+If any packages could not be mirrored, a report is written to `UNRESOLVED_REPORT` (default `./chainguard-unresolved.txt`) with one `reason<tab>name@version` line per package, e.g.:
+
+```
+404	left-pad@9.9.9
+ETARGET	some-pkg@2.0.0
+AUTH	@private/thing@1.0.0
+```
+
+Re-running the script later may pick up packages that were within Chainguard's ingestion cooldown window on the previous run.
+
+## Troubleshooting
+
+### Authentication Errors
+
+**Problem**: `Failed to get CodeArtifact authorization token`
+
+**Solution**: Ensure your AWS credentials are configured correctly:
+```bash
+aws configure
+# or
+aws sts get-caller-identity  # Verify current credentials
+```
+
+### Wrong `yq` detected (pnpm lockfiles)
+
+**Problem**: `Wrong yq detected — this script needs the Go 'mikefarah' yq v4` or a populated pnpm lockfile reporting 0 packages.
+
+**Solution**: Install the Go (mikefarah) build of `yq` v4. The Python (kislyuk) `yq` uses different argument semantics and will parse nothing:
+```bash
+brew install yq
+yq --version   # should mention "mikefarah"
+```
+
+### Package Not Mirrored / Still Unavailable
+
+**Problem**: Packages appear under "Unavailable after N passes" (ETARGET/404) in the summary or in the unresolved report.
+
+**Solution**: This usually means Chainguard had not finished ingesting the package within the retry window — it may be in a cooldown period, malware-blocked, have no verifiable source, or simply not exist. Try:
+- Increasing `INGEST_MAX_PASSES` and/or `INGEST_RETRY_DELAY`
+- Re-running the script later (packages past their cooldown will be picked up)
+
+### Permission Denied
+
+**Problem**: `Error: 403 Forbidden` when publishing to CodeArtifact
+
+**Solution**: Verify your AWS IAM permissions include:
+- `codeartifact:PublishPackageVersion`
+- `codeartifact:PutPackageMetadata`
+- `codeartifact:GetAuthorizationToken`
+- `codeartifact:GetRepositoryEndpoint`
+
+### Scoped Packages Not Found
+
+**Problem**: Scoped packages (e.g., `@types/node`) not appearing in CodeArtifact
+
+**Solution**: Scoped packages are stored with namespaces. Use the AWS CLI with `--namespace` parameter:
+```bash
+aws codeartifact list-packages \
+  --domain my-domain \
+  --repository my-repo \
+  --format npm \
+  --namespace types  # For @types/* packages
+```
+
+## Verifying Mirrored Packages
+
+### Check Package in CodeArtifact
+
+```bash
+# List all packages
+aws codeartifact list-packages \
+  --domain $CODEARTIFACT_DOMAIN \
+  --repository $CODEARTIFACT_REPOSITORY \
+  --format npm
+
+# Check specific package version
+aws codeartifact list-package-versions \
+  --domain $CODEARTIFACT_DOMAIN \
+  --repository $CODEARTIFACT_REPOSITORY \
+  --package express \
+  --format npm
+
+# Check scoped package
+aws codeartifact list-package-versions \
+  --domain $CODEARTIFACT_DOMAIN \
+  --repository $CODEARTIFACT_REPOSITORY \
+  --package fs-minipass \
+  --namespace isaacs \
+  --format npm
+```
+
+### Verify Package Attestations
+
+For packages that originated from npm (via Chainguard fallback), you can verify attestations using cosign:
+
+```bash
+# Download package
+npm pack express@4.18.2 --registry=https://your-codeartifact-url
+
+# Verify attestations
+cosign verify-attestation express-4.18.2.tgz \
+  --type slsaprovenance \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp "^https://github.com/.*/.github/workflows"
+```
+
+## Using Mirrored Packages
+
+Configure your project to use CodeArtifact as the registry:
+
+```bash
+# Login to CodeArtifact
+aws codeartifact login \
+  --tool npm \
+  --domain $CODEARTIFACT_DOMAIN \
+  --repository $CODEARTIFACT_REPOSITORY \
+  --region $AWS_REGION
+
+# Install packages
+npm install
+```
+
+Or configure `.npmrc` manually:
+
+```
+registry=https://your-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com/npm/your-repo/
+//your-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com/npm/your-repo/:_authToken=${CODEARTIFACT_TOKEN}
+```
+
+## Limitations
+
+- **Chainguard-specific attestations**: Registry-specific metadata from Chainguard Libraries is not preserved during mirroring, though the packages themselves are functionally identical
+- **Asynchronous ingestion**: Packages not yet cached by Chainguard are ingested on demand, so some may remain unavailable within a single run's retry window and require a later re-run
+- **Rate limiting**: Large lockfiles may encounter rate limits from source or destination registries
+- **Storage costs**: CodeArtifact charges for storage. Monitor repository size and clean up unused package versions
+
+## Support
+
+For issues related to:
+- **Script functionality**: Review the log file for detailed error messages
+- **Chainguard Libraries**: Contact Chainguard support
+- **AWS CodeArtifact**: Consult AWS documentation or support
+
+## License
+
+This script is provided as-is without warranty. See disclaimer at the top of this document.

--- a/library-copy-aws-code-artifact/readme.md
+++ b/library-copy-aws-code-artifact/readme.md
@@ -177,11 +177,11 @@ Packages that remain unavailable after all passes are classified in the summary 
 
 ## Output and Logging
 
-The script provides color-coded console output and writes detailed logs to the specified log file:
+The script prints timestamped console output and writes the same detailed logs to the specified log file. Messages are tagged by level so they stay readable in CI pipelines and log files:
 
-- **Green**: Informational messages
-- **Yellow**: Warnings (e.g., package not yet available in Chainguard)
-- **Red**: Errors
+- Informational messages are untagged (e.g. `[2026-05-11 10:30:15] Processing express@4.18.2...`)
+- **WARNING:** — warnings (e.g., package not yet available in Chainguard)
+- **ERROR:** — errors
 
 ### Example Output
 

--- a/library-copy-aws-code-artifact/setup-codeartifact.sh
+++ b/library-copy-aws-code-artifact/setup-codeartifact.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# setup-codeartifact.sh
+# Helper script to set up AWS CodeArtifact domain and npm repository
+
+set -e
+
+# Configuration (customize these)
+DOMAIN_NAME="${CODEARTIFACT_DOMAIN:-npm-mirror-test}"
+REPOSITORY_NAME="${CODEARTIFACT_REPOSITORY:-cg-npm-packages}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}AWS CodeArtifact Setup${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Check if AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    echo -e "${RED}ERROR: AWS CLI is not installed.${NC}"
+    echo "Please install it from: https://aws.amazon.com/cli/"
+    exit 1
+fi
+
+# Check AWS credentials
+echo -e "${YELLOW}Checking AWS credentials...${NC}"
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo -e "${RED}ERROR: AWS credentials not configured.${NC}"
+    echo "Please run: aws configure"
+    exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo -e "${GREEN}✓ AWS Account ID: ${ACCOUNT_ID}${NC}"
+echo ""
+
+# Create CodeArtifact domain
+echo -e "${YELLOW}Creating CodeArtifact domain: ${DOMAIN_NAME}${NC}"
+if aws codeartifact describe-domain \
+    --domain "$DOMAIN_NAME" \
+    --region "$AWS_REGION" &> /dev/null; then
+    echo -e "${GREEN}✓ Domain '${DOMAIN_NAME}' already exists${NC}"
+else
+    aws codeartifact create-domain \
+        --domain "$DOMAIN_NAME" \
+        --region "$AWS_REGION" > /dev/null
+    echo -e "${GREEN}✓ Domain '${DOMAIN_NAME}' created${NC}"
+fi
+echo ""
+
+# Create CodeArtifact repository
+echo -e "${YELLOW}Creating CodeArtifact repository: ${REPOSITORY_NAME}${NC}"
+if aws codeartifact describe-repository \
+    --domain "$DOMAIN_NAME" \
+    --repository "$REPOSITORY_NAME" \
+    --region "$AWS_REGION" &> /dev/null; then
+    echo -e "${GREEN}✓ Repository '${REPOSITORY_NAME}' already exists${NC}"
+else
+    aws codeartifact create-repository \
+        --domain "$DOMAIN_NAME" \
+        --repository "$REPOSITORY_NAME" \
+        --description "npm packages mirror from Chainguard" \
+        --region "$AWS_REGION" > /dev/null
+    echo -e "${GREEN}✓ Repository '${REPOSITORY_NAME}' created${NC}"
+fi
+echo ""
+
+# Get repository endpoint
+REPO_ENDPOINT=$(aws codeartifact get-repository-endpoint \
+    --domain "$DOMAIN_NAME" \
+    --repository "$REPOSITORY_NAME" \
+    --format npm \
+    --region "$AWS_REGION" \
+    --query repositoryEndpoint \
+    --output text)
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}Setup Complete!${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "Domain: ${GREEN}${DOMAIN_NAME}${NC}"
+echo -e "Repository: ${GREEN}${REPOSITORY_NAME}${NC}"
+echo -e "Region: ${GREEN}${AWS_REGION}${NC}"
+echo -e "Endpoint: ${GREEN}${REPO_ENDPOINT}${NC}"
+echo ""
+echo -e "${YELLOW}Export these environment variables to use with the mirror script:${NC}"
+echo ""
+echo -e "${BLUE}export AWS_REGION=\"${AWS_REGION}\"${NC}"
+echo -e "${BLUE}export CODEARTIFACT_DOMAIN=\"${DOMAIN_NAME}\"${NC}"
+echo -e "${BLUE}export CODEARTIFACT_REPOSITORY=\"${REPOSITORY_NAME}\"${NC}"
+echo -e "${BLUE}export CODEARTIFACT_DOMAIN_OWNER=\"${ACCOUNT_ID}\"${NC}"
+echo ""
+echo -e "${YELLOW}Don't forget to also set your Chainguard credentials:${NC}"
+echo -e "${BLUE}export CGR_USER=\"your-chainguard-user\"${NC}"
+echo -e "${BLUE}export CGR_TOKEN=\"your-chainguard-token\"${NC}"
+echo ""


### PR DESCRIPTION
Adds a new `library-copy-aws-code-artifact/` example that mirrors npm packages from Chainguard Libraries to a private AWS CodeArtifact repository.

The `npm-codeartifact-mirror.sh` script reads an npm `package-lock.json` **or** a pnpm `pnpm-lock.yaml`, downloads each package from Chainguard's curated npm registry (with fallback to public npm), and publishes them to CodeArtifact. 

## Contents

- `npm-codeartifact-mirror.sh` — the mirror script (npm + pnpm v5/v6/v9 lockfile support, duplicate detection, failure classification, unresolved report)
- `setup-codeartifact.sh` — helper to create a CodeArtifact domain and repository
- `code-artifact-setup.md` — CodeArtifact setup and testing guide
- `readme.md` — prerequisites, configuration, usage, troubleshooting